### PR TITLE
Rename cosmic-flux to cosmic-ext-flux

### DIFF
--- a/applets.ron
+++ b/applets.ron
@@ -141,10 +141,10 @@ Applets(
       image: "https://raw.githubusercontent.com/nwxnw/cosmic-connect-applet/main/screenshots/connected-applet.png"
     ),
     (
-      name: "cosmic-flux",
+      name: "cosmic-ext-flux",
       description: "Live wallpaper engine — play video and GIF files as your desktop background with GPU-accelerated decoding, multi-monitor support, and a panel applet for playback controls.",
-      repo: "https://github.com/franz-net/cosmic-flux",
-      image: "https://raw.githubusercontent.com/franz-net/cosmic-flux/main/assets/screenshot.png"
+      repo: "https://github.com/franz-net/cosmic-ext-flux",
+      image: "https://raw.githubusercontent.com/franz-net/cosmic-ext-flux/main/assets/screenshot.png"
     ),
     (
       name: "cosmic-applet-mare",


### PR DESCRIPTION
The project was renamed from `cosmic-flux` to `cosmic-ext-flux` to comply with the [COSMIC trademark policy](https://github.com/pop-os/cosmic-epoch/blob/master/TRADEMARK.md) (raised in [franz-net/cosmic-ext-flux#5](https://github.com/franz-net/cosmic-ext-flux/issues/5)), adopting the `cosmic-ext-` namespace and an `io.github.franz_net.*` App ID.

This updates the existing applets.ron entry: name, repository URL, and screenshot URL. The old GitHub URLs redirect, so nothing is broken in the meantime — this just makes the listing match the project's actual name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)